### PR TITLE
prevent favicon.ico request

### DIFF
--- a/_headers
+++ b/_headers
@@ -1,6 +1,3 @@
-/*.ico
-  Cache-Control: public, max-age=14400
-  Content-Type: image/x-icon
 /*.css
   Cache-Control: public, max-age=14400
 /

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 
 <head>
   <meta charset="utf-8">
+  <link rel="icon" href="data:">
   <link rel="stylesheet" href="./style.css">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
 


### PR DESCRIPTION
I didn't realise in #14 that the issue was that `favicon.ico` doesn't even exist but browsers look for it by default