### PR TITLE
Add solarhosting, Remove groom

### DIFF
--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
       <li>
         <p><a href="https://solarhosting.cc">Solarhosting</a></p>
         <ul>
-          <li>Solarhosting.cc is a website for discord bots or any NodeJS/Python applications, Its 24/7 and does not require renewals or a creditcard. It has a very generous fee plan and support.</li>
+          <li>Solarhosting.cc is a website for Discord bots or any NodeJS/Python applications, Its 24/7 and does not require renewals or a Credit Card. It has a very generous free plan and support.</li>
         </ul>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -310,17 +310,6 @@
         </ul>
       </li>
       <li>
-        <p><a href="http://goorm.io/">Goorm</a>, Credit: python660</p>
-        <ul>
-          <li>Goorm is a cloud-based development platform originating in South Korea that
-            offers a robust set of features. It provides flexibility in choosing programming languages, database
-            options,
-            and Ubuntu OS versions. With a generous amount of storage and a daily traffic limit of 1GB, it is suitable
-            for
-            both small and medium-sized projects. The platform also supports both public and private projects.</li>
-        </ul>
-      </li>
-      <li>
         <p><a href="https://codesandbox.io/">CodeSandbox</a></p>
         <ul>
           <li>CodeSandbox is an online development environment tailored for web
@@ -416,6 +405,12 @@
         <p><a href="https://danbot.host">Danbot Host</a></p>
         <ul>
           <li>Danbot.Host is a platform which provides hosting for multiple coding languages including static site hosting for free. Also, as stated by them, "We do not limit your resources, you can host as many bots as you want, as many servers as you want, all for free."</li>
+        </ul>
+      </li>
+      <li>
+        <p><a href="https://solarhosting.cc">Solarhosting</a></p>
+        <ul>
+          <li>Solarhosting.cc is a website for discord bots or any NodeJS/Python applications, Its 24/7 and does not require renewals or a creditcard. It has a very generous fee plan and support.</li>
         </ul>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -410,7 +410,7 @@
       <li>
         <p><a href="https://solarhosting.cc">Solarhosting</a></p>
         <ul>
-          <li>Solarhosting.cc is a website for Discord bots or any NodeJS/Python applications, Its 24/7 and does not require renewals or a Credit Card. It has a very generous free plan and support.</li>
+          <li>Solarhosting.cc is a website for Discord bots or any NodeJS/Python applications, It's 24/7 and does not require renewals or a credit card. It has a very generous free plan and support.</li>
         </ul>
       </li>
       <li>


### PR DESCRIPTION
## Added/Removed:
- This pull request adds solar hosting as an alternative to replit that does not need a creditcard
- Removes groom.io as its no longer running
  - Proof: Its been down since Jan 13 according to the internet archive.  https://web.archive.org/web/20240113062409/https://goorm.io/